### PR TITLE
SuperPair: rename .asArray to .components

### DIFF
--- a/SuperBufRd.sc
+++ b/SuperBufRd.sc
@@ -7,9 +7,9 @@ SuperPhasor : MultiOutUGen {
     }
     *new1 { arg ugen_rate, trig, rate, start, end, reset, loop, details;
         var msd, lsd, isPlaying;
-        start = start.asPair.asArray;
-        end = end.asPair.asArray;
-        reset = reset.asPair.asArray;
+        start = start.asPair.components;
+        end = end.asPair.components;
+        reset = reset.asPair.components;
         # msd, lsd, isPlaying = super.new.rate_(ugen_rate).addToSynth.init(([trig, rate] ++ start ++ end ++ reset ++ [loop]));
         if (details) {
             ^[SuperPair(msd, lsd), isPlaying];
@@ -29,9 +29,9 @@ SuperPhasorX : MultiOutUGen {
     }
     *new1 { arg ugen_rate, trig, rate, start, end, reset, loop, overlap;
         var msd0, lsd0, msd1, lsd1, pan0, msd2, lsd2, msd3, lsd3, pan1, pan2, isPlaying;
-        start = start.asPair.asArray;
-        end = end.asPair.asArray;
-        reset = reset.asPair.asArray;
+        start = start.asPair.components;
+        end = end.asPair.components;
+        reset = reset.asPair.components;
         # msd0, lsd0, msd1, lsd1, pan0, msd2, lsd2, msd3, lsd3, pan1, pan2, isPlaying = super.new.rate_(ugen_rate).addToSynth.init(([trig, rate] ++ start ++ end ++ reset ++ [loop, overlap]));
 
         ^[SuperPair(msd0, lsd0), SuperPair(msd1, lsd1), pan0, SuperPair(msd2, lsd2), SuperPair(msd3, lsd3), pan1, pan2, isPlaying];
@@ -47,7 +47,7 @@ SuperBufRd : MultiOutUGen {
         ^this.multiNew('audio', numChannels, bufnum, phase, loop, quality)
     }
     *new1 { arg rate, numChannels, bufnum, phase, loop, quality;
-        phase = phase.asPair.asArray;
+        phase = phase.asPair.components;
         ^super.new.rate_(rate).addToSynth.init(numChannels, [bufnum] ++ phase ++ [loop, quality]);
     }
 

--- a/SuperPair.sc
+++ b/SuperPair.sc
@@ -18,29 +18,20 @@ SuperPair {
         ^(msd + lsd);
     }
 
-    asPair {
-        ^this;
-    }
+    asPair { ^this }
 
-    asArray {
+    asBig { ^this }
+
+    components {
         ^[msd, lsd];
     }
 
-    asBig {
-        ^this;
-    }
-
-    asOSCArgEmbeddedArray { | array|
-		    array = array.add($[);
-		    this.asArray.do{ | e | array = e.asOSCArgEmbeddedArray(array) };
-		    ^array.add($])
+    asOSCArgEmbeddedArray { arg array;
+		    ^this.components.asOSCArgEmbeddedArray(array)
     }
 
     isUGen {
-        if (msd.isUGen or: lsd.isUGen) {
-            ^true;
-        };
-        ^false;
+        ^(msd.isUGen or: lsd.isUGen)
     }
 
     rate {
@@ -85,7 +76,7 @@ SuperPoll : UGen {
         ^in;
     }
     *new1 { arg rate, trig, value, label, trigid;
-        var valueArr = value.asPair.asArray;
+        var valueArr = value.asPair.components;
         label = label ?? { "%".format(value.class) };
         label = label.asString.collectAs(_.ascii, Array);
         if (trig.isNumber) { trig = Impulse.multiNew(rate, trig, 0) };

--- a/Tests/TestSuperPair.sc
+++ b/Tests/TestSuperPair.sc
@@ -1,0 +1,48 @@
+TestSuperPair : UnitTest {
+
+  var server;
+
+	setUp {
+		server = Server(this.class.name);
+    server.bootSync;
+	}
+
+	tearDown {
+		if(server.serverRunning) { server.quit };
+		server.remove;
+	}
+
+
+  test_SuperPair_skrDefaultValue {
+    var condition = Condition();
+    var expected = 3600.00002;
+    var result;
+    {\pos.skr(expected).components}.loadToFloatArray(64/server.sampleRate,server)
+    {|val|
+      result = val[..1].sum.postln;
+      condition.unhang;
+    };
+    condition.hang;
+		this.assertFloatEquals(result, expected, "NamedControl.skr should output precise default value");
+	}
+
+  test_SuperPair_skrSet {
+    var condition = Condition();
+    var expected = 3600.00002;
+    var result, bus, synth;
+    bus = Bus.control(server,2);
+    synth = {|bus|
+        Out.kr(bus,\pos.skr(0).components)
+    }.play(server);
+    server.sync;
+    synth.set(\bus,bus,\pos,expected.asPair);
+    server.sync;
+    synth.free;
+    result = bus.getnSynchronous(2);
+    result = result[..1].sum.postln;
+    bus.free;
+		this.assertFloatEquals(result, expected, "NamedControl.skr should output precise value after set");
+	}
+
+
+}

--- a/extSuperPair.sc
+++ b/extSuperPair.sc
@@ -21,12 +21,12 @@
 
 + Symbol {
     skr { | val, lag, fixedLag = false, spec |
-        var expandedPairs = val.asCollection.collect{|v|v.asPair.asArray}.flat;
+        var expandedPairs = val.asArray.collect{|v|v.asPair.components}.flat;
         ^NamedControl.kr(this, expandedPairs, lag, fixedLag,spec)
         .clump(2).collect(SuperPair(*_)).unbubble
     }
     sar { | val, lag, fixedLag = false, spec |
-        var expandedPairs = val.asCollection.collect{|v|v.asPair.asArray}.flat;
+        var expandedPairs = val.asArray.collect{|v|v.asPair.components}.flat;
         ^NamedControl.ar(this, expandedPairs, lag, fixedLag,spec)
         .clump(2).collect(SuperPair(*_)).unbubble
     }


### PR DESCRIPTION
Return to .asArray default implementation, i.e. return [this]