### PR TITLE
SBOUG: fix UGen * SuperPair

### DIFF
--- a/SuperPair.sc
+++ b/SuperPair.sc
@@ -32,6 +32,12 @@ SuperPair : AbstractFunction {
 		    ^this.components.asOSCArgEmbeddedArray(array)
     }
 
+    // or in other words: don't pass SuperPair around normal UGens
+    // - prevent unwanted conversions/multichannel-expansion
+    // - make sure SuperPair is handled only by "prepared" UGens
+    // - allow performBinaryOpOnUGen to fire when doing (UGen * SuperPair)
+    isValidUGenInput { ^false }
+
     isUGen {
         ^(msd.isUGen or: lsd.isUGen)
     }
@@ -74,6 +80,10 @@ SuperPair : AbstractFunction {
               BinaryOpFunction.new(aSelector, something, this.asFloat, adverb).value
             )
         }
+    }
+    // ops like (UGen * SuperPair) should return a SuperBinaryOpUGen
+    performBinaryOpOnUGen { arg aSelector, aUGen;
+        ^aUGen.asPair.perform(aSelector, this)
     }
 
     composeNAryOp { arg aSelector, anArgList;

--- a/SystemOverwrites/extSuperPair.sc
+++ b/SystemOverwrites/extSuperPair.sc
@@ -29,6 +29,16 @@
     superPoll { arg trig = 10, label, trigid = -1;
         ^SuperPoll.ar(trig, this, label, trigid);
     }
+
+    composeBinaryOp { arg aSelector, anInput;
+    		if (anInput.isValidUGenInput, {
+    			^BinaryOpUGen.new(aSelector, this, anInput)
+    		},{
+          // adding a return statement here (check out UGen:composeBinaryOp)
+          // so we can return a SuperBinaryOpUGen
+    			^anInput.performBinaryOpOnUGen(aSelector, this);
+    		});
+	  }
 }
 
 + Symbol {

--- a/Tests/TestSuperBinaryOpUGen.sc
+++ b/Tests/TestSuperBinaryOpUGen.sc
@@ -1,0 +1,26 @@
+TestSuperBinaryOpUGen : UnitTest {
+
+  var server;
+
+	setUp {
+		server = Server(this.class.name);
+    // server.bootSync; // boot only in tests that need it
+	}
+
+	tearDown {
+		if(server.serverRunning) { server.quit };
+		server.remove;
+	}
+
+  test_SBOUG_Order_SuperPairTimesUGen {
+    var op = (3600.002.asPair*DC.kr);
+		this.assertEquals(op.class, SuperPair, "SuperPair times UGen should return a SuperPair");
+	}
+
+  test_SBOUG_Order_UGenTimesSuperPair {
+    var op = (DC.kr*3600.002.asPair);
+		this.assertEquals(op.class, SuperPair, "UGen times SuperPair should return a SuperPair");
+	}
+
+
+}


### PR DESCRIPTION
This is issue is a bit strange, as it fails somehow differently on my machine and @esluyter's
Anyway, in theory, this shouldn't work:
```
DC.kr(10) * 3600.0002.asPair
```
Since the left-hand is a UGen, it would generate a BinaryOpUGen instead of a Super one.
This PR fixes it:
- making SuperPair's isValidUGenInput false, so that UGen.composeBinaryOp calls SuperPair.performBinaryOpOnUGen
- overwriting UGen.composeBinaryOp to fix a bug (missing return statement), thus making this extension work also in sc versions where it's not fixed (I sent a PR to fix it, I'm positive it will be fixed in future SC versions)
